### PR TITLE
update DNS records for Tock

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @GSA-TTS/tts-tech-operations
+

--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -291,13 +291,13 @@ resource "aws_route53_record" "d_18f_gov__acme_challenge_atf-eregs_18f_gov_cname
 #   records = ["d1a8iv0i0iazmn.cloudfront.net"]
 # }
 
- resource "aws_route53_record" "d_18f_gov_atf-eregs_18f_gov_cname" {
-   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-   name    = "atf-eregs.18f.gov."
-   type    = "CNAME"
-   ttl     = 120
-   records = ["atf-eregs.18f.gov.external-domains-production.cloud.gov."]
- }
+resource "aws_route53_record" "d_18f_gov_atf-eregs_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "atf-eregs.18f.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["atf-eregs.18f.gov.external-domains-production.cloud.gov."]
+}
 
 resource "aws_route53_record" "d_18f_gov_atul-docker-presentation_18f_gov_a" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
@@ -1074,14 +1074,6 @@ resource "aws_route53_record" "d_18f_gov_testing-cookbook_18f_gov_aaaa" {
     zone_id                = local.cloud_gov_cloudfront_zone_id
     evaluate_target_health = false
   }
-}
-
-resource "aws_route53_record" "d_18f_gov_tock_18f_gov_cname" {
-  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
-  name    = "tock.18f.gov."
-  type    = "CNAME"
-  ttl     = 300
-  records = ["production-domains-1-884689640.us-gov-west-1.elb.amazonaws.com."]
 }
 
 resource "aws_route53_record" "d_18f_gov_writing-lab-guide_18f_gov_a" {

--- a/terraform/tock.18f.gov.tf
+++ b/terraform/tock.18f.gov.tf
@@ -7,11 +7,10 @@ resource "aws_route53_record" "tock_18f_gov_acmechallenge" {
   records = ["_acme-challenge.tock.18f.gov.external-domains-production.cloud.gov."]
 }
 
-resource "aws_route53_record" "tock_18f_gov_cname" {
+resource "aws_route53_record" "d_18f_gov_tock_18f_gov_cname" {
   zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
   name    = "tock.18f.gov."
   type    = "CNAME"
-
-  ttl     = 600
-  records = ["tock.18f.gov.external-domains-production.cloud.gov."]
+  ttl     = 300
+  records = ["production-domains-1-884689640.us-gov-west-1.elb.amazonaws.com."]
 }

--- a/terraform/tock.18f.gov.tf
+++ b/terraform/tock.18f.gov.tf
@@ -1,0 +1,17 @@
+resource "aws_route53_record" "tock_18f_gov_acmechallenge" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "_acme-challenge.tock.18f.gov."
+  type    = "CNAME"
+
+  ttl     = 600
+  records = ["_acme-challenge.tock.18f.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "tock_18f_gov_cname" {
+  zone_id = aws_route53_zone.d_18f_gov_zone.zone_id
+  name    = "tock.18f.gov."
+  type    = "CNAME"
+
+  ttl     = 600
+  records = ["tock.18f.gov.external-domains-production.cloud.gov."]
+}


### PR DESCRIPTION
Updates DNS records for tock.18f.gov to comply with[ expected values from the external domain service](https://cloud.gov/docs/services/external-domain-service/#how-to-create-an-instance-of-this-service)
