### PR TITLE
Add Updates for Digital.gov

### DIFF
--- a/terraform/digital.gov.tf
+++ b/terraform/digital.gov.tf
@@ -391,7 +391,7 @@ resource "aws_route53_record" "designsystem_digital_gov_aaaa" {
 }
 
 # v2.designsystem.digital.gov — CNAME -------------------------------
-# (Redirects to designsystem.digital.gov via "pages redirect")
+# (Redirects to designsystem.digital.gov via WAF)
 resource "aws_route53_record" "v2_designsystem_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "v2.designsystem.digital.gov."
@@ -433,23 +433,7 @@ resource "aws_route53_record" "v1_designsystem_digital_gov_aaaa" {
   }
 }
 
-# components.designsystem.digital.gov — CNAME -------------------------------
-resource "aws_route53_record" "components_designsystem_digital_gov_cname" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "components.designsystem.digital.gov."
-  type    = "CNAME"
-  ttl     = 1800
-  records = ["components.designsystem.digital.gov.external-domains-production.cloud.gov."]
-}
 
-# _acme-challenge.components.designsystem.digital.gov — CNAME -------------------------------
-resource "aws_route53_record" "_acme-challenge_components_designsystem_digital_gov_cname" {
-  zone_id = aws_route53_zone.digital_toplevel.zone_id
-  name    = "_acme-challenge.components.designsystem.digital.gov."
-  type    = "CNAME"
-  ttl     = 1800
-  records = ["_acme-challenge.components.designsystem.digital.gov.external-domains-production.cloud.gov."]
-}
 
 # public-sans.digital.gov — A
 resource "aws_route53_record" "public_sans_digital_gov_a" {
@@ -475,6 +459,7 @@ resource "aws_route53_record" "public_sans_digital_gov_aaaa" {
 }
 
 # accessibility.digital.gov — CNAME -------------------------------
+# (Redirects to digital.gov/guides/accessibility-for-teams via WAF)
 resource "aws_route53_record" "accessibility_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "accessibility.digital.gov."
@@ -492,6 +477,7 @@ resource "aws_route53_record" "_acme-challenge_accessibility_digital_gov_cname" 
 }
 
 # emerging.digital.gov — CNAME -------------------------------
+# (Redirects to digital.gov/topics/emerging-tech via WAF)
 resource "aws_route53_record" "emerging_digital_gov_cname" {
   zone_id = aws_route53_zone.digital_toplevel.zone_id
   name    = "emerging.digital.gov."


### PR DESCRIPTION
This pull request updates DNS configurations in `terraform/digital.gov.tf` to reflect changes in redirection mechanisms and removes unused records. The most important changes include updating comments to indicate the use of WAF for redirection, removing obsolete DNS records, and adding comments for new redirection targets.

### Updates to redirection mechanisms:
* Updated the comment for `v2.designsystem.digital.gov` to indicate that it now redirects via WAF instead of "pages redirect." (`[terraform/digital.gov.tfL394-R394](diffhunk://#diff-7e88474e27c494bff142d19ec849c1cd0cf95fc3566a89d07d265ccb45167e1aL394-R394)`)
* Added comments for new WAF-based redirection targets, such as `accessibility.digital.gov` and `emerging.digital.gov`. (`[[1]](diffhunk://#diff-7e88474e27c494bff142d19ec849c1cd0cf95fc3566a89d07d265ccb45167e1aR462)`, `[[2]](diffhunk://#diff-7e88474e27c494bff142d19ec849c1cd0cf95fc3566a89d07d265ccb45167e1aR480)`)

### Removal of unused DNS records:
* Removed DNS records for `components.designsystem.digital.gov` and its associated ACME challenge record, as they are no longer needed. (`[terraform/digital.gov.tfL436-L452](diffhunk://#diff-7e88474e27c494bff142d19ec849c1cd0cf95fc3566a89d07d265ccb45167e1aL436-L452)`)