### PR TITLE
Add parked domain skipping in email test and park 18F

### DIFF
--- a/terraform/18f.gov.tf
+++ b/terraform/18f.gov.tf
@@ -3,7 +3,9 @@ resource "aws_route53_zone" "d_18f_gov_zone" {
   name = "18f.gov."
 
   tags = {
-    Project = "dns"
+    Project = "dns",
+    # REMOVE THE parked TAG IF RE-POPULATING THIS ZONE! parked="true" will cause validation tests to be skipped
+    parked  = "true"
   }
 }
 


### PR DESCRIPTION
We want to be able to "park" a domain (leave it empty with only SOA and NS records). That had been done for 18f.gov and was causing a failure in the 2nd level SPF/DMARC tests. This adds a "parked" tag concept to allow adding Key: "parked", Value: "true" to a domain in Route53 and then skip that domin in the email security test.