### PR TITLE
Add temporary search.gov subdomain for testing

### DIFF
--- a/terraform/search.gov.tf
+++ b/terraform/search.gov.tf
@@ -46,6 +46,24 @@ resource "aws_route53_record" "www_search_gov_acme_challenge" {
   records = ["_acme-challenge.www.search.gov.external-domains-production.cloud.gov."]
 }
 
+## TEMPORARY for validation of planned hosting setup 2025-08-08
+resource "aws_route53_record" "whtnfrvemzeq_search_gov_acme_challenge" {
+  zone_id = aws_route53_zone.search_toplevel.zone_id
+  name    = "_acme-challenge.whtnfrvemzeq.search.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["_acme-challenge.whtnfrvemzeq.search.gov.external-domains-production.cloud.gov."]
+}
+
+## TEMPORARY for validation of planned hosting setup 2025-08-08
+resource "aws_route53_record" "search_gov_whtnfrvemzeq" {
+  zone_id = aws_route53_zone.search_toplevel.zone_id
+  name    = "whtnfrvemzeq.search.gov."
+  type    = "CNAME"
+  ttl     = 120
+  records = ["whtnfrvemzeq.search.gov.external-domains-production.cloud.gov."]
+}
+
 # www.search.gov — redirects to search.gov through pages_redirect
 resource "aws_route53_record" "search_gov_www" {
   zone_id = aws_route53_zone.search_toplevel.zone_id


### PR DESCRIPTION
I want to use this subdomain to validate the configuration (routes and nginx config) we're going to use to serve search.gov traffic after switchover. Once I've done that I'll put in a PR to take it back out. 

- [ ] This is a new public-facing site _(if so, please follow the additional instructions below)_
   - [ ] Provide context
   - [ ] Assign to `@GSA-TTS/tts-tech-operations` for review
   - [ ] Review [GSA Pages Requirements](https://handbook.tts.gsa.gov/gsa-pages)
   - [ ] Review [TTS Digital Council's new site review process](https://docs.google.com/document/d/1j6eieL3oop0rxCAldVVh7uGdOCG-ajafrog_BZ-u470/edit) completed
   - [ ] Update [the inventory](https://docs.google.com/spreadsheets/d/1OBO6g7_OsVBv0vG8WSCI6L2FD_iRh3A7a_6eQWj2zLE/edit?ts=6025575d#gid=2013137748) with new site information
