### PR TITLE
Remove search.gov and www.search.gov CNAME and ALIAS records temporarily

### DIFF
--- a/terraform/search.gov.tf
+++ b/terraform/search.gov.tf
@@ -6,29 +6,37 @@ resource "aws_route53_zone" "search_toplevel" {
   }
 }
 
-resource "aws_route53_record" "search_gov_apex" {
-  zone_id = aws_route53_zone.search_toplevel.zone_id
-  name    = "search.gov."
-  type    = "A"
+# resource "aws_route53_record" "search_gov_apex" {
+#   zone_id = aws_route53_zone.search_toplevel.zone_id
+#   name    = "search.gov."
+#   type    = "A"
 
-  alias {
-    name                   = "dcp2c9fh8vtdl.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
+#   alias {
+#     name                   = "dcp2c9fh8vtdl.cloudfront.net."
+#     zone_id                = local.cloud_gov_cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
 
-resource "aws_route53_record" "search_gov_apex_aaaa" {
-  zone_id = aws_route53_zone.search_toplevel.zone_id
-  name    = "search.gov."
-  type    = "AAAA"
+# resource "aws_route53_record" "search_gov_apex_aaaa" {
+#   zone_id = aws_route53_zone.search_toplevel.zone_id
+#   name    = "search.gov."
+#   type    = "AAAA"
 
-  alias {
-    name                   = "dcp2c9fh8vtdl.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
+#   alias {
+#     name                   = "dcp2c9fh8vtdl.cloudfront.net."
+#     zone_id                = local.cloud_gov_cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
+
+# resource "aws_route53_record" "search_gov_www_cname" {
+#   zone_id = aws_route53_zone.search_toplevel.zone_id
+#   name    = "www.search.gov."
+#   type    = "CNAME"
+#   ttl     = 120
+#   records = ["www.search.gov.external-domains-production.cloud.gov."]
+# }
 
 resource "aws_route53_record" "search_gov_acme_challenge" {
   zone_id = aws_route53_zone.search_toplevel.zone_id
@@ -46,6 +54,7 @@ resource "aws_route53_record" "www_search_gov_acme_challenge" {
   records = ["_acme-challenge.www.search.gov.external-domains-production.cloud.gov."]
 }
 
+
 ## TEMPORARY for validation of planned hosting setup 2025-08-08
 resource "aws_route53_record" "whtnfrvemzeq_search_gov_acme_challenge" {
   zone_id = aws_route53_zone.search_toplevel.zone_id
@@ -62,31 +71,6 @@ resource "aws_route53_record" "search_gov_whtnfrvemzeq" {
   type    = "CNAME"
   ttl     = 120
   records = ["whtnfrvemzeq.search.gov.external-domains-production.cloud.gov."]
-}
-
-# www.search.gov — redirects to search.gov through pages_redirect
-resource "aws_route53_record" "search_gov_www" {
-  zone_id = aws_route53_zone.search_toplevel.zone_id
-  name    = "www.search.gov."
-  type    = "A"
-
-  alias {
-    name                   = "dv0x4a4ilr842.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "search_gov_www_aaaa" {
-  zone_id = aws_route53_zone.search_toplevel.zone_id
-  name    = "www.search.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "dv0x4a4ilr842.cloudfront.net."
-    zone_id                = local.cloud_gov_cloudfront_zone_id
-    evaluate_target_health = false
-  }
 }
 
 # find.search.gov


### PR DESCRIPTION
Per step 4 of https://gist.github.com/markdboyd/be7e7588074d057e53ec92f39bc03aa6