### PR TITLE
Update checkdmarc requirement to address bugs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3~=1.26
-checkdmarc~=5.8
+checkdmarc~=5.9
 pytest~=7.3
 dnspython~=2.6.0rc1
 urllib3~=1.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3~=1.26
-checkdmarc~=4.6
+checkdmarc~=5.8
 pytest~=7.3
 dnspython~=2.6.0rc1
 urllib3~=1.26


### PR DESCRIPTION
- Crashing when domains have an MTA-STS policy https://github.com/domainaware/checkdmarc/pull/166
- SPF record parsing bugs
  - https://github.com/domainaware/checkdmarc/issues/155
  - https://github.com/domainaware/checkdmarc/pull/158
  - https://github.com/domainaware/checkdmarc/issues/128
  - https://github.com/domainaware/checkdmarc/pull/147

It's awesome to see my project being used to secure government domains.